### PR TITLE
Fix versioning for Pale Moon

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -17,7 +17,7 @@
       <Description>
       <em:id>{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}</em:id>
       <em:minVersion>28.14.0</em:minVersion>
-      <em:maxVersion>29.*</em:maxVersion>
+      <em:maxVersion>99.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     <em:targetApplication>


### PR DESCRIPTION
30.x has been recalled, so Pale Moon should be able to be targeted normally again.